### PR TITLE
[Fix/#26] 평균 매매가 조회 시 주변 & 타겟 매매가를 날짜 기준으로 가공한다

### DIFF
--- a/src/main/java/com/searchsquare/house/service/HouseServiceImpl.java
+++ b/src/main/java/com/searchsquare/house/service/HouseServiceImpl.java
@@ -10,6 +10,8 @@ import com.searchsquare.house.service.dto.SearchAroundPriceCond;
 import com.searchsquare.house.service.dto.SearchHouseCond;
 import com.searchsquare.house.service.dto.SearchHouseDealCond;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,6 +59,9 @@ public class HouseServiceImpl implements HouseService {
     public AroundPriceDto getAroundPriceList(SearchAroundPriceCond cond) {
         List<HousePriceDto> target = houseRepository.getTargetPriceList(cond);
         List<HousePriceDto> around = houseRepository.getAroundPriceList(cond);
+        Set<String> yearSet = target.stream().map(HousePriceDto::getYear)
+            .collect(Collectors.toSet());
+        around.removeIf(dto -> !yearSet.contains(dto.getYear()));
         return AroundPriceDto.builder()
             .target(target)
             .around(around)


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #26 

### 어떤 작업을 했나요?
- 날짜 기준으로 리스트를 필터링

### Other
- 